### PR TITLE
Add support for token secret and realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # axios-oauth-1.0a
 
+Easily add OAuth 1.0a signing to your axios client
+
 ## Getting Started
 
 * `npm i axios-oauth-1.0a`
@@ -55,6 +57,7 @@ const options = {
     secret: 'yyy',
 };
 
+// Add interceptor that signs requests
 addOAuthInterceptor(client, options);
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
+# axios-oauth-1.0a
+
+## Getting Started
+
+* `npm i axios-oauth-1.0a`
+
+## OAuth Options
+
+### algorithm
+
+* The hashing function to use for the `oauth_signature` value
+* Available values are: `HMAC-SHA1`, `HMAC-SHA256`
+* Default value is `HMAC-SHA256`
+
+### includeBodyHash
+
+* When `true`, always try to hash the body and include the hash in the signature
+* When `false`, never try to calculate `oauth_body_hash`
+* When `'auto'`, calculate `oauth_body_hash` on `PUT` or `POST` requests that have a body
+
+### key
+
+* The Consumer Key value
+
+### realm
+
+* An optional value to set the OAuth 1.0 realm
+
+### secret
+
+* The Consumer Secret value
+
+### token
+
+* The Access Token value
+
+### tokenSecret
+
+* An optional value to specify the access token secret
+
+## Example
 
 To sign your axios requests using OAuth 1.0a:
 
@@ -7,11 +48,17 @@ import addOAuthInterceptor from 'axios-oauth-1.0a';
 // Create a client whose requests will be signed
 const client = axios.create();
 
-// Add interceptor that signs requests
-// HMAC-SHA1 and HMAC-SHA256 are supported
-const oauthKey = 'xxx';
-const oauthSecret = 'yyy';
-const oauthMethod = 'HMAC-SHA1'
-addOAuthInterceptor(client, oauthKey, oauthSecret, oauthMethod);
+// Specify the OAuth options
+const options = {
+    algorithm: 'HMAC-SHA1',
+    key: 'xxx',
+    secret: 'yyy',
+};
+
+addOAuthInterceptor(client, options);
 ```
 
+## Documentation
+
+* [RFC5849 - The OAuth 1.0 Protocol](https://datatracker.ietf.org/doc/html/rfc5849)
+* [Axios Interceptors](https://axios-http.com/docs/interceptors)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,14 +33,6 @@ const calculateBodyHash = (
     .digest("base64");
 };
 
-const isNonEmptyString = (val: any): boolean => {
-  if (typeof val !== "string") {
-    return false;
-  }
-
-  return val.length > 0;
-}
-
 export interface OAuthInterceptorConfig {
   /**
    * Hashing function to use
@@ -62,7 +54,7 @@ export interface OAuthInterceptorConfig {
   /**
    * OAuth realm
    */
-  realm: string | undefined;
+  realm?: string | undefined;
 
   /**
    * Consumer secret
@@ -86,7 +78,7 @@ const addOAuthInterceptor = (
     algorithm = "HMAC-SHA256",
     includeBodyHash = "auto",
     key,
-    realm = undefined,
+    realm,
     secret,
     token = null,
     tokenSecret = null,
@@ -104,7 +96,7 @@ const addOAuthInterceptor = (
 
     // if provided, oauth_token can be included in the oauth parameters
     // more information: https://datatracker.ietf.org/doc/html/rfc5849#section-3.1
-    if (isNonEmptyString(token)) {
+    if (token) {
       oauthParams.oauth_token = token;
     }
 
@@ -163,14 +155,14 @@ const addOAuthInterceptor = (
       oauthUrl.toString(),
       paramsToSign,
       secret,
-      tokenSecret || token
+      tokenSecret
     );
 
     // realm should not be included in the signature calculation
     // but is optional in the OAuth 1.0 Authorization header
     // so we need to add it after signing the request
     // more information: https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.1.3.1
-    if (isNonEmptyString(realm)) {
+    if (realm) {
       oauthParams.realm = realm;
     }
 


### PR DESCRIPTION
Hello!
This Pull Request adds the ability for consumers of this module to specify a token secret and realm.

I was unable to authenticate properly when using this module to intercept `axios` requests to NetSuite. After some investigation I discovered a few things NetSuite required but this module did not support.

These changes "should" be backwards compatible but I do not have any tests (existing or added) to prove that.

I also updated the `README.md` to provide more information about this module.

Thanks!