### PR TITLE
signature calculations should include the body hash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,10 @@ const addOAuthInterceptor = (
         includeBodyHash === "auto" &&
         ["POST", "PUT"].includes(method))
     ) {
-      oauthParams.oauth_body_hash = calculateBodyHash(algorithm, config.data);
+      oauthParams.oauth_body_hash = paramsToSign.oauth_body_hash = calculateBodyHash(
+        algorithm,
+        config.data
+      );
     }
 
     oauthParams.oauth_signature = sign(


### PR DESCRIPTION
According to the OAuth Request Body Hash spec the OAuth signature should include the body hash in the signature calculation:

```
This specification describes a method to provide an integrity check on non-form-encoded request bodies. The normal OAuth signature base string is enhanced by adding an additional parameter with the hash of the request body. An unkeyed hash is used for the reasons described in Appendix C.
```
from: https://tools.ietf.org/id/draft-eaton-oauth-bodyhash-00.html

Version 0.2.1 of this package on npmjs contains the following lines inside of the addOAuthInterceptor function

```typescript
oauthParams.oauth_body_hash = paramsToSign.oauth_body_hash = calculateBodyHash(
  algorithm,
  config.data
);
```

As far as I can tell this line does not exist in any actual commit in git but it appears to be the correct implementation. The current implementation does not include the body hash in the signature calculation as required by the specification. The included changes restores the correct behavior from the 0.2.1 release to npm.