### PR TITLE
Support: OAuth Callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Easily add OAuth 1.0a signing to your axios client
 
 * An optional value to specify the access token secret
 
+### callback
+
+* An optional value to set the callback url
+
 ## Example
 
 To sign your axios requests using OAuth 1.0a:

--- a/src/addOAuthInterceptor.test.ts
+++ b/src/addOAuthInterceptor.test.ts
@@ -10,6 +10,7 @@ const testRequest = async function (
   oauthConsumerSecret: string,
   token: string | null,
   tokenSecret: string | null,
+  callback: string | null,
   method: "GET" | "POST",
   url: string,
   data?: string | URLSearchParams | null,
@@ -24,6 +25,7 @@ const testRequest = async function (
     secret: oauthConsumerSecret,
     token,
     tokenSecret,
+    callback,
   });
   const mock = new MockAdapter(client);
   mock.onGet().reply(function (config) {
@@ -111,6 +113,7 @@ const testRequest = async function (
     oauth_timestamp: expect.any(String),
     oauth_version: "1.0",
     ...(token && { oauth_token: token }),
+    ...(callback && { oauth_callback: callback }),
   });
 
   // Strip off search and hash for signature calculation
@@ -136,6 +139,7 @@ describe("addOAuthInterceptor", () => {
       "s",
       "t",
       "ts",
+      null,
       "GET",
       "http://test/test",
       null
@@ -146,6 +150,7 @@ describe("addOAuthInterceptor", () => {
       "HMAC-SHA1",
       "k",
       "s",
+      null,
       null,
       null,
       "GET",
@@ -160,6 +165,7 @@ describe("addOAuthInterceptor", () => {
       "s",
       "t",
       "ts",
+      null,
       "POST",
       "http://test/test",
       "test=hello"
@@ -170,6 +176,7 @@ describe("addOAuthInterceptor", () => {
       "HMAC-SHA1",
       "k",
       "s",
+      null,
       null,
       null,
       "POST",
@@ -184,6 +191,7 @@ describe("addOAuthInterceptor", () => {
       "s",
       null,
       null,
+      null,
       "POST",
       "http://test/test?test=1",
       null
@@ -196,6 +204,7 @@ describe("addOAuthInterceptor", () => {
       "s",
       null,
       null,
+      null,
       "POST",
       "http://test/test",
       null,
@@ -204,6 +213,34 @@ describe("addOAuthInterceptor", () => {
         ["r", "2"],
         ["q", "qq"],
       ])
+    );
+  });
+  it("adds HMAC-SHA1 signature to simple POST request with callback URL", async () => {
+    await testRequest(
+      "HMAC-SHA1",
+      "k",
+      "s",
+      null,
+      null,
+      "http://test/callback",
+      "POST",
+      "http://test/test",
+      null,
+      null
+    );
+  });
+  it("adds HMAC-SHA256 signature to simple POST request with callback URL", async () => {
+    await testRequest(
+      "HMAC-SHA256",
+      "k",
+      "s",
+      null,
+      null,
+      "http://test/callback",
+      "POST",
+      "http://test/test",
+      null,
+      null
     );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,11 @@ export interface OAuthInterceptorConfig {
    * OAuth token secret
    */
   tokenSecret?: string | null;
+
+  /**
+   * OAuth callback URL
+   */
+  callback?: string | null;
 }
 
 const addOAuthInterceptor = (
@@ -82,6 +87,7 @@ const addOAuthInterceptor = (
     secret,
     token = null,
     tokenSecret = null,
+    callback = null,
   }: OAuthInterceptorConfig
 ) => {
   client.interceptors.request.use((config: AxiosRequestConfig) => {
@@ -98,6 +104,10 @@ const addOAuthInterceptor = (
     // more information: https://datatracker.ietf.org/doc/html/rfc5849#section-3.1
     if (token) {
       oauthParams.oauth_token = token;
+    }
+
+    if (callback) {
+      oauthParams.oauth_callback = callback;
     }
 
     const oauthUrl = new URL(


### PR DESCRIPTION
Add support to OAuth Callback URL.

[RFC Ref](https://datatracker.ietf.org/doc/html/rfc5849#section-2.1)